### PR TITLE
Fix quick diff when one file empty

### DIFF
--- a/git_compare/diff_utils.py
+++ b/git_compare/diff_utils.py
@@ -1,14 +1,29 @@
 import difflib
 import streamlit as st
 
+
 @st.cache_data
 def quick_diff_lines(content1: str, content2: str) -> int:
     """นับบรรทัดที่ต่างกันแบบเร็ว (ไม่ต้องสร้าง Side-by-Side Diff)"""
-    if not content1 or not content2:
+    if content1 is None:
+        content1 = ""
+    if content2 is None:
+        content2 = ""
+
+    lines1 = content1.splitlines()
+    lines2 = content2.splitlines()
+
+    if not lines1 and not lines2:
         return 0
-    diffs = list(difflib.ndiff(content1.splitlines(), content2.splitlines()))
-    changed = sum(1 for d in diffs if d.startswith('+') or d.startswith('-'))
+    if not lines1:
+        return len(lines2)
+    if not lines2:
+        return len(lines1)
+
+    diffs = list(difflib.ndiff(lines1, lines2))
+    changed = sum(1 for d in diffs if d.startswith("+") or d.startswith("-"))
     return changed
+
 
 @st.cache_data
 def make_side_by_side_diff(content1: str, content2: str, desc1: str, desc2: str) -> str:
@@ -20,5 +35,5 @@ def make_side_by_side_diff(content1: str, content2: str, desc1: str, desc2: str)
         fromdesc=desc1,
         todesc=desc2,
         context=False,
-        numlines=0
+        numlines=0,
     )


### PR DESCRIPTION
## Summary
- handle empty file content in quick diff util

## Testing
- `python -m py_compile git_compare/diff_utils.py git_compare/repo_manager.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b05b7ce48333989f3aabb24e7d59